### PR TITLE
[bench] add a benchmark from icu-messageformat-parser to be able to compare

### DIFF
--- a/intl_markdown/Cargo.toml
+++ b/intl_markdown/Cargo.toml
@@ -35,3 +35,7 @@ path = "./examples/gen-html-entities.rs"
 [[bench]]
 name = "long_documents"
 harness = false
+
+[[bench]]
+name = "icu_messageformat_parser_bench"
+harness = false

--- a/intl_markdown/benches/icu_messageformat_parser_bench.rs
+++ b/intl_markdown/benches/icu_messageformat_parser_bench.rs
@@ -1,0 +1,66 @@
+use criterion::{Criterion, criterion_group, criterion_main, Throughput};
+
+use intl_markdown::parse_intl_message;
+
+fn parse_message(message: &str) {
+    parse_intl_message(message, false);
+}
+
+fn parse_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("messages");
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("complex messages", |b| {
+        b.iter(|| {
+        parse_message(r#"
+            {gender_of_host, select,
+                female {
+                    {num_guests, plural,
+                        =0 {{host} does not give a party.}
+                        =1 {{host} invites <em>{guest}</em> to her party.}
+                        =2 {{host} invites <em>{guest}</em> and <em>one</em> other person to her party.}
+                        other {{host} invites <em>{guest}</em> and <em>#</em> other people to her party.}
+                    }
+                }
+                male {
+                    {num_guests, plural,
+                        =0 {{host} does not give a party.}
+                        =1 {{host} invites <em>{guest}</em> to his party.}
+                        =2 {{host} invites <em>{guest}</em> and one other person to his party.}
+                        other {{host} invites <em>{guest}</em> and <em>#</em> other people to his party.}
+                    }
+                }
+                other {
+                    {num_guests, plural,
+                        =0 {{host} does not give a party.}
+                        =1 {{host} invites <em>{guest}</em> to their party.}
+                        =2 {{host} invites <em>{guest}</em> and one other person to their party.}
+                        other {{host} invites <em>{guest}</em> and <em>#</em> other people to their party.}
+                    }
+                }
+            }"#
+        )});
+    });
+
+    group.bench_function("normal message", |b| {
+        b.iter(|| {
+            parse_message(
+                r#"
+            Yo, {firstName} {lastName} has
+            {numBooks, number, integer}
+            {numBooks, plural,
+                one {book}
+                other {books}
+            }
+        "#,
+            )
+        });
+    });
+    group.bench_function("simple message", |b| {
+        b.iter(|| parse_message(r#"Hello, {name}"#));
+    });
+    group.bench_function("string message", |b| {
+        b.iter(|| parse_message(r#"Hello, world"#));
+    });
+}
+criterion_group!(benches, parse_bench);
+criterion_main!(benches);


### PR DESCRIPTION
This copies the benchmark from https://github.com/formatjs/formatjs/blob/f3bb540bea4614bbd22d4e80521d7a63101684e0/packages/icu-messageformat-parser/benchmark.js to be able to compare roughly how well the ICUMarkdown parser performs.

Importantly, it will _never_ be as fast as the fastest pure-ICU parser, since Markdown rules require a lot of extra logic that the parser has to jump through. That said, hopefully it can still beat out the fastest js-based parser (it doesn't currently...only about 60% as fast, but still 4x faster than the old FormatJS parser).