### PR TITLE
Add `eco local-pack` command for building compiled versions of all packages in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target/
 # Build artifacts
 *.wasm
 *.node
+.local-packs/

--- a/tools/src/db/commands.js
+++ b/tools/src/db/commands.js
@@ -4,13 +4,30 @@ import { npmPublish, npmPublishCommand } from '../npm.js';
 import { getPackage } from '../pnpm.js';
 import { buildNapiPackage, NAPI_TARGET_MAP } from '../napi.js';
 import { checkAllVersionsEqual, getPackageFamily, versionCommand } from '../versioning.js';
+import { hostPlatform } from '../util/platform.js';
 
-const targetOption = new Option(
-  '--target <target>',
-  'Which platform package to build for natively.',
-)
-  .choices(Object.keys(NAPI_TARGET_MAP))
-  .makeOptionMandatory(true);
+/**
+ * Return a new option, `--target`, that specifies which build target should be used for the parent
+ * command.
+ *
+ * Target names are the platform-package names, not the actual host triple from the system. More
+ * information about the host can be looked up using `NAPI_TARGET_MAP` or the `platform` utils.
+ *
+ * `local` can also be given to automatically determine and use the host platform as the target.
+ *
+ * @returns {Option}
+ */
+export function buildTargetOption() {
+  const option = new Option('--target <target>', 'Which platform package to build for natively.')
+    .choices(Object.keys(NAPI_TARGET_MAP).concat(['local']))
+    .argParser((target) => {
+      console.log(hostPlatform);
+      return target === 'local' ? hostPlatform.target : target;
+    })
+    .makeOptionMandatory(true);
+
+  return option;
+}
 
 const DB_PACKAGE_NAME = '@discord/intl-message-database';
 
@@ -25,23 +42,22 @@ export default async function () {
   group
     .command('build')
     .description('Build the intl_message_database native Node extension')
-    .addOption(targetOption)
+    .addOption(buildTargetOption({ allowHostDefault: true }))
     .action(async ({ target }) => {
       await buildNapiPackage(dbPackage, target);
     });
 
   group.addCommand(versionCommand('version', dbPackage, dbFamily));
-
+  group.addCommand(npmPublishCommand('publish-root', dbPackage));
   group.addCommand(
     npmPublishCommand('publish-target')
       .description('Publish a platform-specific package for intl-message-database to npm')
-      .addOption(targetOption)
+      .addOption(buildTargetOption({ allowHostDefault: true }))
       .action(async (options) => {
         const targetPackage = await getPackage(`@discord/intl-message-database-${options.target}`);
         await npmPublish(targetPackage, options);
       }),
   );
-
   group.addCommand(
     npmPublishCommand('publish-all')
       .description(
@@ -56,12 +72,6 @@ export default async function () {
           await npmPublish(pack, options);
         }
       }),
-  );
-
-  group.addCommand(
-    npmPublishCommand('publish-root').action(
-      async (options) => await npmPublish(dbPackage, options),
-    ),
   );
 
   return group;

--- a/tools/src/util/platform.js
+++ b/tools/src/util/platform.js
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { __dirname } from '../constants.js';
+import { NAPI_TARGET_MAP } from '../napi.js';
+
+function isMusl() {
+  // For Node 10
+  if (!process.report || typeof process.report.getReport !== 'function') {
+    try {
+      const lddPath = require('child_process').execSync('which ldd').toString().trim();
+      return fs.readFileSync(lddPath, 'utf8').includes('musl');
+    } catch (e) {
+      return true;
+    }
+  } else {
+    const { glibcVersionRuntime } = JSON.parse(process.report.getReport()).header;
+    return !glibcVersionRuntime;
+  }
+}
+
+/** @type {Record<string, Record<string, string>>} */
+const PACKAGE_NAMES = {
+  android: { arm: 'android-arm-eabi', arm64: 'android-arm64' },
+  win32: { arm64: 'win32-arm64-msvc', ia32: 'win32-ia32-msvc', x64: 'win32-x64-msvc' },
+  darwin: { arm64: 'darwin-arm64', x64: 'darwin-x64' },
+  freebsd: { x64: 'freebsd-x64' },
+  'linux-gnu': {
+    arm: 'linux-arm-gnueabihf',
+    arm64: 'linux-arm64-gnu',
+    x64: 'linux-64-gnu',
+    riscv64: 'linux-riscv64-gnu',
+    s390x: 'linux-s390x-gnu',
+  },
+  'linux-musl': {
+    arm: 'linux-arm-musleabihf',
+    arm64: 'linux-arm64-musl',
+    x64: 'linux-64-musl',
+    riscv64: 'linux-riscv64-musl',
+  },
+};
+
+const platform =
+  process.platform !== 'linux' ? process.platform : 'linux-' + isMusl() ? 'musl' : 'gnu';
+const arch = process.arch;
+
+/**
+ * @returns {string}
+ */
+function getPackageName() {
+  if (!(platform in PACKAGE_NAMES)) {
+    throw new Error(`Unsupported OS: ${platform}`);
+  }
+  if (!(arch in PACKAGE_NAMES[platform])) {
+    throw new Error(`Unsupported architecture for ${platform}: ${arch}`);
+  }
+  return PACKAGE_NAMES[platform][arch];
+}
+
+const packageName = getPackageName();
+const localPath = path.join(
+  __dirname,
+  `npm/${packageName}/intl-message-database.${packageName}.node`,
+);
+const packagePath = `@discord/intl-message-database-${packageName}`;
+
+/**
+ * Information about the host system that's running this command, usable for creating default
+ * targets and argument values that rely on a target platform or package.
+ * @type {{packagePath: string, triple: *, localPath: string, target: string}}
+ */
+const hostPlatform = {
+  target: packageName,
+  triple: NAPI_TARGET_MAP[packageName],
+  packagePath,
+  localPath,
+};
+
+export { hostPlatform };


### PR DESCRIPTION
I don't think this will actually work for installing a package with other dependencies from the workspace, since pnpm will just use a plain version specifier rather than a tarball path, and it doesn't seem like there's a way to hook that resolution atm.