### PR TITLE
[perf][exporter][ast][runtime] Support fully stringifying static messages

### DIFF
--- a/crates/keyless_json/src/lib.rs
+++ b/crates/keyless_json/src/lib.rs
@@ -1,4 +1,5 @@
-pub use serializer::{Serializer, to_string, to_writer};
+pub use serializer::{to_string, to_writer, Serializer};
+pub use string::write_escaped_str_contents;
 
 mod error;
 mod serializer;

--- a/crates/keyless_json/src/string.rs
+++ b/crates/keyless_json/src/string.rs
@@ -1,7 +1,7 @@
 //! Adapted almost entirely from serde_json's string formatting.
 use std::io::Write;
 
-pub(crate) fn write_escaped_str_contents<W>(writer: &mut W, value: &str) -> std::io::Result<()>
+pub fn write_escaped_str_contents<W>(writer: &mut W, value: &str) -> std::io::Result<()>
 where
     W: ?Sized + Write,
 {

--- a/packages/intl-ast/index.ts
+++ b/packages/intl-ast/index.ts
@@ -293,5 +293,5 @@ export function isCompressedAst(
   if (!Array.isArray(node)) return false;
   // Otherwise just check the first element. If it's an array or a direct string, then the ast is
   // compressed as keyless.
-  return Array.isArray(node[0]) || typeof node[0] === 'string';
+  return Array.isArray(node[0]) || typeof node[0] === 'string' || typeof node === 'string';
 }

--- a/packages/intl-ast/index.ts
+++ b/packages/intl-ast/index.ts
@@ -289,9 +289,11 @@ export function isCompressedAst(node: AstNode[] | FullFormatJsNode[]): node is A
 export function isCompressedAst(
   node: AstNode | FullFormatJsNode | AstNode[] | FullFormatJsNode[],
 ): boolean {
+  if (typeof node === 'string') return true;
+
   // Not an array at all means this is a singular fully-typed node.
   if (!Array.isArray(node)) return false;
   // Otherwise just check the first element. If it's an array or a direct string, then the ast is
   // compressed as keyless.
-  return Array.isArray(node[0]) || typeof node[0] === 'string' || typeof node === 'string';
+  return Array.isArray(node[0]) || typeof node[0] === 'string';
 }

--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -26,7 +26,7 @@
     "prepublishOnly": "pnpm build:release"
   },
   "dependencies": {
-    "@discord/intl-ast": "workspace:*",
+    "@discord/intl-ast": "file:../intl-ast",
     "@formatjs/icu-skeleton-parser": "1.8.2",
     "@formatjs/intl": "^2.10.1",
     "@intrnl/xxhash64": "^0.1.2",

--- a/packages/intl/package.json
+++ b/packages/intl/package.json
@@ -26,7 +26,7 @@
     "prepublishOnly": "pnpm build:release"
   },
   "dependencies": {
-    "@discord/intl-ast": "file:../intl-ast",
+    "@discord/intl-ast": "workspace:*",
     "@formatjs/icu-skeleton-parser": "1.8.2",
     "@formatjs/intl": "^2.10.1",
     "@intrnl/xxhash64": "^0.1.2",

--- a/packages/intl/src/format.ts
+++ b/packages/intl/src/format.ts
@@ -238,7 +238,7 @@ export function bindFormatValuesWithBuilder<T, Builder extends FormatBuilder<T>>
 
 export function bindFormatValues<Result>(
   Builder: FormatBuilderConstructor<Result>,
-  nodes: AstNode[],
+  nodes: string | AstNode[],
   locales: string | string[],
   formatters: Formatters,
   formatConfig: FormatConfig,
@@ -246,14 +246,19 @@ export function bindFormatValues<Result>(
   currentPluralValue?: number,
 ): Result[] {
   const builder = new Builder();
-  bindFormatValuesWithBuilder(
-    builder,
-    nodes,
-    locales,
-    formatters,
-    formatConfig,
-    values,
-    currentPluralValue,
-  );
-  return builder.finish();
+  if (typeof nodes === 'string') {
+    builder.pushLiteralText(nodes);
+    return builder.finish();
+  } else {
+    bindFormatValuesWithBuilder(
+      builder,
+      nodes,
+      locales,
+      formatters,
+      formatConfig,
+      values,
+      currentPluralValue,
+    );
+    return builder.finish();
+  }
 }

--- a/packages/intl/src/intl-manager.ts
+++ b/packages/intl/src/intl-manager.ts
@@ -116,20 +116,7 @@ export class IntlManager {
    * immediately return the plain string value of the message in the current locale.
    */
   string<T extends TypedIntlMessageGetter<{}>>(message: T): string {
-    const resolved = message(this.currentLocale);
-    if (resolved == null || resolved.ast.length === 0) return '';
-
-    let result = '';
-    for (const element of resolved.ast) {
-      if (typeof element !== 'string') {
-        throw new Error(
-          'Attempted to call `string` formatting on a non-literal message: ' +
-            JSON.stringify(resolved),
-        );
-      }
-      result += element;
-    }
-    return result;
+    return message(this.currentLocale).reserialize();
   }
 
   /**

--- a/packages/intl/src/message.ts
+++ b/packages/intl/src/message.ts
@@ -10,7 +10,7 @@ import {
 
 export class InternalIntlMessage {
   locale: string;
-  ast: AstNode[];
+  ast: string | AstNode[];
 
   constructor(messageOrAst: AstNode[] | FullFormatJsNode[], locale: string) {
     this.locale = locale;
@@ -22,6 +22,8 @@ export class InternalIntlMessage {
    * formatting or values applied.
    */
   reserialize(): string {
+    if (typeof this.ast === 'string') return this.ast;
+
     const result = { value: '' };
     serializeAst(this.ast, result);
     return result.value;

--- a/tools/src/ci/commands.js
+++ b/tools/src/ci/commands.js
@@ -76,17 +76,15 @@ export default async function () {
     .action(async ({ dryRun, tag, failFast }) => {
       await git.rejectIfHasChanges(true);
 
-      console.log({
+      const options = {
         commit: git.currentHead(),
         publish: dryRun ? 'false' : 'true',
         'fail-fast': failFast ? 'true' : 'false',
         tag,
-      });
+      };
 
-      const run = await gh.runWorkflow('release.yaml', {
-        commit: git.currentHead(),
-        publish: dryRun ? 'false' : 'true',
-      });
+      console.log(options);
+      const run = await gh.runWorkflow('release.yaml', options);
 
       logWorkflowRunResponseOrExit(run);
     });


### PR DESCRIPTION
This PR makes any message that contains no variables into a single static string object in the exported bundle files. Previously, all strings were always wrapped in at least one level of array (like `["hello"]`), but I think this is a small performance bottleneck for json parsing. Not much, but certainly a little bit, especially over the course of 5-10k messages being parsed at a time.

Additionally, multi-part static strings, like those containing special characters, are now also collapsed into single strings, like `["it", "'", "s monday"]` was split out because `'` is a special character in the AST, but the runtime doesn't care about that when there's no semantic meaning to it. So now that message will get bundled into `"it's monday"`, saving effort both on json parsing and rendering, since more cases can use the plain-string optimizations at runtime.