### PR TITLE
[markdown] Extend Markdown rules to support common CJK formatting grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cjk"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c5581b1ff873217332789ccc8956c1c68bcf9d693e7e5c6bcc677897fda5257"
+dependencies = [
+ "hex",
+ "lazy_static",
+ "unicode-blocks",
+ "widestring",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +806,7 @@ name = "intl_markdown"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "cjk",
  "criterion",
  "intl_markdown_macros",
  "keyless_json",
@@ -2449,6 +2462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
+name = "unicode-blocks"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b12e05d9e06373163a9bb6bb8c263c261b396643a99445fe6b9811fd376581b"
+
+[[package]]
 name = "unicode-id"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,6 +2670,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "widestring"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"

--- a/crates/intl_markdown/Cargo.toml
+++ b/crates/intl_markdown/Cargo.toml
@@ -13,6 +13,7 @@ doctest = false
 
 [dependencies]
 bitflags = "2"
+cjk = "0.2.5"
 intl_markdown_macros = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/intl_markdown/src/token.rs
+++ b/crates/intl_markdown/src/token.rs
@@ -19,6 +19,12 @@ bitflags! {
         // Only used for some delimiters currently. `ESCAPED` kinds will also
         // always have this set.
         const IS_ESCAPED = 1 << 6;
+
+        // Extension for support delimiters around CJK script characters.
+        // https://talk.commonmark.org/t/emphasis-and-east-asian-text/2491/5
+        // https://github.com/commonmark/cmark/pull/208
+        const HAS_PRECEDING_CJK_PUNCTUATION = 1 << 5;
+        const HAS_FOLLOWING_CJK = 1 << 6;
     }
 }
 
@@ -38,6 +44,13 @@ impl TokenFlags {
 
     pub fn is_escaped(&self) -> bool {
         self.contains(TokenFlags::IS_ESCAPED)
+    }
+
+    pub fn has_preceding_cjk_punctuation(&self) -> bool {
+        self.contains(TokenFlags::HAS_PRECEDING_CJK_PUNCTUATION)
+    }
+    pub fn has_following_cjk(&self) -> bool {
+        self.contains(TokenFlags::HAS_FOLLOWING_CJK)
     }
 }
 

--- a/crates/intl_markdown/tests/md_extensions.rs
+++ b/crates/intl_markdown/tests/md_extensions.rs
@@ -3,6 +3,38 @@
 
 mod harness;
 
+/// Chinese and Japanese content usually do _not_ include spaces between formatted and unformatted
+/// segments  of a single phrase, such as `**{value}**件の投稿`. But this is technically not valid
+/// `strong`  formatting according to the CommonMark spec, since the right flank of the ending
+/// delimiter is a non-space Unicode character.
+///
+/// See more information in the CommonMark discussion here:
+/// https://talk.commonmark.org/t/emphasis-and-east-asian-text/2491/5
+/// https://github.com/commonmark/cmark/pull/208
+///
+/// Because this library is explicitly intended to support many languages including most Asian
+/// languages, we are adding an extension to the Markdown rules to accommodate these situations.
+/// The following tests assert that the special cases for East Asian languages function in a
+/// logically-similar way to Western languages.
+mod asian_punctuation {
+    use crate::harness::icu_string_test;
+    icu_string_test!(
+        japanese_adjacent_formatting,
+        "**{value}**件の投稿",
+        r#"<b>{value}</b>件の投稿"#
+    );
+    icu_string_test!(
+        japanese_spaced_formatting,
+        "**{value}** 件の投稿",
+        r#"<b>{value}</b> 件の投稿"#
+    );
+    icu_string_test!(
+        korean_western_punctuation,
+        "*스크립트(script)*라고",
+        r#"<i>스크립트(script)</i>라고"#
+    );
+}
+
 mod hooks {
     use crate::harness::ast_test;
     ast_test!(


### PR DESCRIPTION
Chinese and Japanese content usually do _not_ include spaces between formatted and unformatted segments  of a single phrase, such as `**{value}**件の投稿`. But this is technically not valid `strong`  formatting according to the CommonMark spec, since the right flank of the ending delimiter is a non-space Unicode character.

See more information in the CommonMark discussion here:
https://talk.commonmark.org/t/emphasis-and-east-asian-text/2491/5
https://github.com/commonmark/cmark/pull/208

Because this library is explicitly intended to support many languages including most Asian languages, we are adding an extension to the Markdown rules to accommodate these situations. The following tests assert that the special cases for East Asian languages function in a logically-similar way to Western languages.

The tests for this change are pretty small, as I'm not fluent in anything near CJK and have purely gone off of suggestions and forums to enumerate these. Most importantly, `**{value}**件の投稿`, is now treated as a **bold** `value` followed by plain text, rather than being completely ignored.