### PR TITLE
[loader] Fix IntlMessagesProxy trap for getOwnPropertyDescriptor

### DIFF
--- a/packages/intl/src/runtime-utils.ts
+++ b/packages/intl/src/runtime-utils.ts
@@ -72,12 +72,8 @@ export function makeMessagesProxy(loader: MessageLoader): Record<string, IntlMes
       return Reflect.ownKeys(self);
     },
     getOwnPropertyDescriptor(self, prop) {
-      return {
-        value: (self[prop] ||= makeBind(prop as string)),
-        configurable: true,
-        enumerable: true,
-        writable: false,
-      };
+      self[prop] ||= makeBind(prop as string);
+      return Reflect.getOwnPropertyDescriptor(self, prop);
     },
     get(self, prop) {
       if (prop === '$$typeof') {


### PR DESCRIPTION
The descriptor returned from the trap differs from the one that exists in baseObject, which throws an error