### PR TITLE
Report non-object `meta`'s as definition errors

### DIFF
--- a/crates/intl_database_core/src/database/source.rs
+++ b/crates/intl_database_core/src/database/source.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 use crate::{KeySymbol, MessageMeta, MessageValue, SourceFileKind, SourceFileMeta};
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum MessageSourceError {
     #[error("Failed to parse message {0} source: {1}")]
     ParseError(SourceFileKind, String),

--- a/crates/intl_database_js_source/src/lib.rs
+++ b/crates/intl_database_js_source/src/lib.rs
@@ -1,6 +1,6 @@
 use intl_database_core::{
     key_symbol, KeySymbol, MessageDefinitionSource, MessageSourceError, MessageSourceResult,
-    RawMessageDefinition, SourceFileKind, SourceFileMeta,
+    RawMessageDefinition, SourceFileKind, SourceFileMeta, DEFAULT_LOCALE,
 };
 use swc_common::sync::Lrc;
 use swc_common::SourceMap;
@@ -14,7 +14,7 @@ pub struct JsMessageSource;
 
 impl MessageDefinitionSource for JsMessageSource {
     fn get_default_locale(&self, _file_name: &str) -> KeySymbol {
-        key_symbol("en-US")
+        key_symbol(DEFAULT_LOCALE)
     }
 
     fn extract_definitions(


### PR DESCRIPTION
Resolves the TODO by recording the invalid meta as a failed definition (this doesn't feel 100% correct as the meta isn't an actual translatable message, but it's better than it being swallowed). Also replaces an "en-US" magic string in the JS source parsing crate with a use of the default language constant from the core crate.

#### Testing

- [x] `cd crates/intl_database_js_source && cargo test` passes.
- [x] Unit tests included.