### PR TITLE
[markdown] simplify handling of backslash-escaped backslashes

### DIFF
--- a/crates/intl_markdown/src/ast/process.rs
+++ b/crates/intl_markdown/src/ast/process.rs
@@ -4,7 +4,6 @@ use crate::ast::{CodeBlockKind, HeadingKind, IcuPluralKind, LinkDestination, Lin
 use crate::html_entities::get_html_entity;
 use crate::token::{SourceText, Token};
 use crate::tree_builder::{cst, TokenSpan};
-use crate::util::unescape_cow;
 use crate::{ast, SyntaxKind};
 
 use super::util::unescape;
@@ -341,17 +340,16 @@ pub fn process_inline_token(
     }
 
     let has_trailing_newline = token.has_trailing_newline();
-    let text = get_text_with_replaced_references(context, &token);
-    let mut unescaped = unescape_cow(&text);
+    let mut text = get_text_with_replaced_references(context, &token);
     // If there's a trailing newline, we have to copy and append the buffer no matter what.
     let result = if include_trailing_trivia && has_trailing_newline {
-        unescaped.to_mut().push_str("\n");
-        unescaped.to_string()
+        text.to_mut().push_str("\n");
+        text.to_string()
     } else {
         if include_trailing_trivia {
-            unescaped.to_mut().push_str(&token.trailing_trivia_text());
+            text.to_mut().push_str(&token.trailing_trivia_text());
         }
-        unescaped.to_string()
+        text.to_string()
     };
     ast::InlineContent::Text(result)
 }

--- a/crates/intl_markdown/src/lexer.rs
+++ b/crates/intl_markdown/src/lexer.rs
@@ -532,13 +532,14 @@ impl<'source> Lexer<'source> {
     /// valid escape sequences, or `text` if the next character would not create
     /// a valid escape.
     fn consume_escaped(&mut self) -> SyntaxKind {
-        self.state.last_token_was_escape = true;
-        self.current_flags.insert(TokenFlags::IS_ESCAPED);
         self.advance();
 
         if self.is_eof() {
             return SyntaxKind::TEXT;
         }
+
+        self.state.last_token_was_escape = true;
+        self.current_flags.insert(TokenFlags::IS_ESCAPED);
 
         match self.current() {
             // Escaped backticks are treated specially when discovering code

--- a/crates/intl_markdown/src/token.rs
+++ b/crates/intl_markdown/src/token.rs
@@ -400,7 +400,11 @@ impl Token {
     }
 
     pub fn text(&self) -> &str {
-        &self.source[self.range_usize()]
+        if self.flags.is_escaped() {
+            &self.source[(self.range.start + 1) as usize..self.range.end as usize]
+        } else {
+            &self.source[self.range_usize()]
+        }
     }
 
     pub fn range(&self) -> TextSpan {

--- a/crates/intl_markdown/tests/mod.rs
+++ b/crates/intl_markdown/tests/mod.rs
@@ -64,6 +64,8 @@ fn autolinks(input: &str, output: &str) {
 #[test_case("[foo](/bar\\* \"ti\\*tle\")", "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>"; "example_22")]
 // #[test_case("[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"", "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>"; "example_23")]
 #[test_case("``` foo\\+bar\nfoo\n```", "<pre><code class=\"language-foo+bar\">foo\n</code></pre>"; "example_24")]
+#[test_case("Appends ¯\\\\_(ツ)_/¯ to your message.", "<p>Appends ¯\\_(ツ)_/¯ to your message.</p>"; "shrug_command")]
+#[test_case("Appends ¯\\\\\\_(ツ)_/¯ to your message.", "<p>Appends ¯\\_(ツ)_/¯ to your message.</p>"; "shrug_command_2")]
 fn backslash_escapes(input: &str, output: &str) {
     run_spec_test(input, output);
 }


### PR DESCRIPTION
This doesn't affect output on anything, but avoids the need for an `unescape_cow` call, and feels more conceptually correct.