### PR TITLE
Fix incorrect base64 implementation

### DIFF
--- a/crates/intl_message_utils/src/lib.rs
+++ b/crates/intl_message_utils/src/lib.rs
@@ -32,7 +32,7 @@ pub fn hash_message_key(content: &str) -> String {
         BASE64_TABLE[((input[1] & 0x0f) << 2 | input[2] >> 6) as usize],
         BASE64_TABLE[(input[2] & 0x3f) as usize],
         BASE64_TABLE[(input[3] >> 2) as usize],
-        BASE64_TABLE[((input[3] & 0x03) << 4 | input[3] >> 4) as usize],
+        BASE64_TABLE[((input[3] & 0x03) << 4 | input[4] >> 4) as usize],
     ];
 
     // SAFETY: We built this string out of ASCII characters, it doesn't need to

--- a/packages/intl/src/hash.ts
+++ b/packages/intl/src/hash.ts
@@ -37,6 +37,6 @@ export function runtimeHashMessageKey(key: string): string {
     BASE64_TABLE[((bytes[1] & 0x0f) << 2) | (bytes[2] >> 6)],
     BASE64_TABLE[bytes[2] & 0x3f],
     BASE64_TABLE[bytes[3] >> 2],
-    BASE64_TABLE[((bytes[3] & 0x03) << 4) | (bytes[3] >> 4)],
+    BASE64_TABLE[((bytes[3] & 0x03) << 4) | (bytes[4] >> 4)],
   ].join('');
 }

--- a/packages/swc-intl-message-transformer/src/transformer.rs
+++ b/packages/swc-intl-message-transformer/src/transformer.rs
@@ -127,11 +127,11 @@ mod tests {
         import messages from "some/module.messages";
         import differentMess from "different.messages";
         import other from "another/place";
-        console.log(messages["Q5kgoa"]);
+        console.log(messages["Q5kgob"]);
         console.log(other.NOT_A_STRING);
         something.messages.WHAT;
-        messages["nWsV4+"].anotherThing;
-        differentMess["PuzRxM"];
+        messages["nWsV48"].anotherThing;
+        differentMess["PuzRxG"];
         "#,
         )
     }
@@ -160,8 +160,8 @@ mod tests {
         import {untouchedSameSpec, t} from "@app/intl";
         import {untranslated} from "somewhere/else";
         import messages from "some.messages";
-        console.log(t["Q5kgoa"]);
-        console.log(messages["Q5kgoa"]);
+        console.log(t["Q5kgob"]);
+        console.log(messages["Q5kgob"]);
         console.log(untranslated.SOME_STRING);
         console.log(untouchedSameSpec.SOME_STRING);
         "#,


### PR DESCRIPTION
The previous base64 encoding implementation only used 32 bits of entropy from the 64 bit hash, duplicating the last 4 bits.

u64 hash
${\texttt{{\color{red}76543210} {\color{orange}76543210} {\color{yellow}76543210} {\color{lightgreen}76543210} {\color{green}76543210} {\color{teal}76543210} {\color{blue}76543210} {\color{magenta}76543210}}}$
before
$\texttt{00{\color{red}765432} 00{\color{red}10}{\color{orange}7654} 00{\color{orange}3210}{\color{yellow}76} 00{\color{yellow}543210} 00{\color{lightgreen}765432} 00{\color{lightgreen}10}{\color{lightgreen}7654}}$
after
$\texttt{00{\color{red}765432} 00{\color{red}10}{\color{orange}7654} 00{\color{orange}3210}{\color{yellow}76} 00{\color{yellow}543210} 00{\color{lightgreen}765432} 00{\color{lightgreen}10}{\color{green}7654}}$

This change should reduce the probability of a collision happening - due to the birthday paradox, given a set of 75000 unique keys, there is a 50% chance that at least two keys share the same hash. With 36 bits the chance is decreased to roughly 4%.
