### PR TITLE
add eslint rule for no variable type mismatches

### DIFF
--- a/crates/intl_validator/src/diagnostic.rs
+++ b/crates/intl_validator/src/diagnostic.rs
@@ -18,6 +18,7 @@ pub enum DiagnosticName {
     NoUnsafeVariableSyntax,
     NoNonExhaustivePlurals,
     NoUnnecessaryPlural,
+    NoVariableTypeMismatches,
 }
 
 impl Display for DiagnosticName {
@@ -41,6 +42,7 @@ impl DiagnosticName {
             DiagnosticName::NoUnsafeVariableSyntax => "NoUnsafeVariableSyntax",
             DiagnosticName::NoNonExhaustivePlurals => "NoNonExhaustivePlurals",
             DiagnosticName::NoUnnecessaryPlural => "NoUnnecessaryPlural",
+            DiagnosticName::NoVariableTypeMismatches => "NoVariableTypeMismatches",
         }
     }
 }

--- a/crates/intl_validator/src/lib.rs
+++ b/crates/intl_validator/src/lib.rs
@@ -1,6 +1,8 @@
 extern crate core;
 
-use intl_database_core::{KeySymbolSet, Message};
+use std::collections::HashSet;
+
+use intl_database_core::{KeySymbolSet, Message, MessageVariableType};
 
 pub use crate::category::DiagnosticCategory;
 pub use crate::content::validate_message_value;
@@ -22,6 +24,41 @@ fn variable_name_list(names: &KeySymbolSet) -> String {
     names.join(", ")
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum VariableTypeGroup {
+    Any,
+    Numeric,
+    String,
+    Date,
+    Function,
+    Handler,
+}
+
+fn variable_type_group(kind: &MessageVariableType) -> VariableTypeGroup {
+    match kind {
+        MessageVariableType::Any => VariableTypeGroup::Any,
+        MessageVariableType::Number
+        | MessageVariableType::Plural
+        | MessageVariableType::NumericEnum { .. } => VariableTypeGroup::Numeric,
+        MessageVariableType::Enum { .. } => VariableTypeGroup::String,
+        MessageVariableType::Date | MessageVariableType::Time => VariableTypeGroup::Date,
+        MessageVariableType::HookFunction | MessageVariableType::LinkFunction => {
+            VariableTypeGroup::Function
+        }
+        MessageVariableType::HandlerFunction => VariableTypeGroup::Handler,
+    }
+}
+
+/// Returns true if `translation` is a variable type that is assignable to `source`. If `translation` is
+/// `Any`, then `source` is always considered assignable (i.e., the type is widening).
+/// Otherwise, the types must be equal to be considered assignable.
+fn is_assignable_variable_type(
+    source: &VariableTypeGroup,
+    translation: &VariableTypeGroup,
+) -> bool {
+    *translation == VariableTypeGroup::Any || source == translation
+}
+
 /// Validate the content of a message across all of its translations, returning
 /// a full set of diagnostics with information about each one.
 ///
@@ -31,16 +68,29 @@ fn variable_name_list(names: &KeySymbolSet) -> String {
 /// unsupported syntax.
 pub fn validate_message(message: &Message) -> Vec<MessageDiagnostic> {
     let has_source = message.source_locale().is_some();
-    let (source_visible_variables, source_locale) =
+    let (source_visible_variables, source_variables, source_locale) =
         if let Some(source) = message.get_source_translation() {
             (
                 source.variables.visible_variable_names(),
+                Some(&source.variables),
                 // SAFETY: If the source exists, then the locale for it must also exist.
                 Some(message.source_locale().unwrap()),
             )
         } else {
-            (Default::default(), None)
+            (Default::default(), None, None)
         };
+
+    let source_variable_types: Option<Vec<_>> = source_variables.map(|vars| {
+        vars.iter()
+            .map(|(name, instances)| {
+                let groups: HashSet<VariableTypeGroup> = instances
+                    .iter()
+                    .map(|inst| variable_type_group(&inst.kind))
+                    .collect();
+                (name, groups)
+            })
+            .collect()
+    });
 
     let mut diagnostics = MessageDiagnosticsBuilder::new(message.key());
 
@@ -100,6 +150,40 @@ pub fn validate_message(message: &Message) -> Vec<MessageDiagnostic> {
                 span: None,
                 fixes: vec![],
             });
+        }
+
+        if let Some(source_var_types) = &source_variable_types {
+            for (name, source_groups) in source_var_types {
+                if let Some(translation_instances) = translation.variables.get(name) {
+                    let translation_groups: HashSet<VariableTypeGroup> = translation_instances
+                        .iter()
+                        .map(|inst| variable_type_group(&inst.kind))
+                        .collect();
+
+                    let all_assignable = source_groups.iter().all(|source_group| {
+                        translation_groups.iter().any(|translation_group| {
+                            is_assignable_variable_type(source_group, translation_group)
+                        })
+                    });
+
+                    if !all_assignable {
+                        diagnostics.add(MessageDiagnostic {
+                            key: message.key(),
+                            file_position: translation.file_position,
+                            locale: locale.clone(),
+                            name: DiagnosticName::NoVariableTypeMismatches,
+                            category: DiagnosticCategory::Correctness,
+                            description: format!(
+                                "Variable '{variable}' has a mismatched type between the source and translation",
+                                variable = AsRef::<str>::as_ref(name),
+                            ),
+                            help: Some("The variable type in the translation should match the source message. Consider a new string or update translations to match the source.".into()),
+                            span: None,
+                            fixes: vec![],
+                        });
+                    }
+                }
+            }
         }
     }
 

--- a/crates/intl_validator/tests/rules/mod.rs
+++ b/crates/intl_validator/tests/rules/mod.rs
@@ -5,3 +5,4 @@ mod no_non_exhaustive_plurals;
 mod no_repeated_plural_names;
 mod no_unnecessary_plural;
 mod no_unsafe_variable_syntax;
+mod no_variable_type_mismatches;

--- a/crates/intl_validator/tests/rules/no_variable_type_mismatches.rs
+++ b/crates/intl_validator/tests/rules/no_variable_type_mismatches.rs
@@ -1,0 +1,163 @@
+use crate::harness;
+use intl_database_core::{key_symbol, Message, MessageMeta};
+use intl_validator::{validate_message, DiagnosticName, MessageDiagnostic};
+
+fn build_message(source_content: &str, translation_content: &str) -> Message {
+    let key = "MESSAGE_KEY";
+    let source = harness::define_single_message(key, source_content);
+    let translation = harness::define_single_message(key, translation_content);
+
+    let mut message = Message::from_definition(
+        key_symbol(key),
+        source,
+        key_symbol("en-US"),
+        MessageMeta::default(),
+    );
+    message.set_translation(key_symbol("fr"), translation);
+    message
+}
+
+fn validate(source_content: &str, translation_content: &str) -> Vec<MessageDiagnostic> {
+    let message = build_message(source_content, translation_content);
+    validate_message(&message)
+        .into_iter()
+        .filter(|d| d.name == DiagnosticName::NoVariableTypeMismatches)
+        .collect()
+}
+
+#[test]
+fn safe_new_source_and_old_translation_same_type_variables() {
+    assert_eq!(validate("{user}", "{user}").len(), 0);
+    assert_eq!(validate("hello {user}", "bonjour {user}").len(), 0);
+    assert_eq!(validate("{count, number}", "{count, number}").len(), 0);
+    assert_eq!(validate("{today, date}", "{today, date}").len(), 0);
+    assert_eq!(
+        validate(
+            "{count, plural, one {# item} other {# items}}",
+            "{count, plural, one {# item} other {# items}}",
+        )
+        .len(),
+        0
+    );
+    assert_eq!(
+        validate(
+            "{gender, select, male {He} female {She} other {They}}",
+            "{gender, select, male {He} female {She} other {They}}",
+        )
+        .len(),
+        0
+    );
+    assert_eq!(
+        validate("$[click here](myVar)", "$[cliquez ici](myVar)").len(),
+        0
+    );
+    assert_eq!(
+        validate("[click here](myVar)", "[cliquez ici](myVar)").len(),
+        0
+    );
+}
+
+#[test]
+fn safe_new_source_specialized_and_old_translation_any_type_variables() {
+    assert_eq!(validate("{count, number}", "{count}").len(), 0);
+    assert_eq!(validate("{today, date}", "{today}").len(), 0);
+    assert_eq!(validate("{now, time}", "{now}").len(), 0);
+    assert_eq!(
+        validate("{count, plural, one {# item} other {# items}}", "{count}").len(),
+        0
+    );
+    assert_eq!(
+        validate(
+            "{gender, select, male {He} female {She} other {They}}",
+            "{gender}"
+        )
+        .len(),
+        0
+    );
+}
+
+#[test]
+fn unsafe_new_source_any_and_old_translation_number_variable() {
+    let diagnostics = validate("{count}", "{count, number}");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].name,
+        DiagnosticName::NoVariableTypeMismatches
+    );
+}
+
+#[test]
+fn unsafe_new_source_any_and_old_translation_date_variable() {
+    let diagnostics = validate("{today}", "{today, date}");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].name,
+        DiagnosticName::NoVariableTypeMismatches
+    );
+}
+
+#[test]
+fn unsafe_new_source_any_and_old_translation_time_variable() {
+    let diagnostics = validate("{now}", "{now, time}");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].name,
+        DiagnosticName::NoVariableTypeMismatches
+    );
+}
+
+#[test]
+fn unsafe_new_source_number_and_old_translation_date_variable() {
+    let diagnostics = validate("{val, number}", "{val, date}");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].name,
+        DiagnosticName::NoVariableTypeMismatches
+    );
+}
+
+#[test]
+fn safe_new_source_function_and_old_translation_any_variable() {
+    assert_eq!(validate("$[text](myVar)", "{myVar}").len(), 0);
+    assert_eq!(validate("[text](myVar)", "{myVar}").len(), 0);
+}
+
+#[test]
+fn unsafe_new_source_any_and_old_translation_hook_variable() {
+    let diagnostics = validate("{var1}", "$[text](var1)");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].name,
+        DiagnosticName::NoVariableTypeMismatches
+    );
+}
+
+#[test]
+fn unsafe_new_source_any_and_old_translation_handler_variable() {
+    let diagnostics = validate("{var1}", "[link](var1)");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].name,
+        DiagnosticName::NoVariableTypeMismatches
+    );
+}
+
+#[test]
+fn unsafe_new_source_hook_and_old_translation_handler_variable() {
+    let diagnostics = validate("$[click here](myVar)", "[click here](myVar)");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].name,
+        DiagnosticName::NoVariableTypeMismatches
+    );
+}
+
+#[test]
+fn unsafe_new_source_handler_and_old_translation_hook_variable() {
+    let diagnostics = validate("[click here](myVar)", "$[click here](myVar)");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].name,
+        DiagnosticName::NoVariableTypeMismatches
+    );
+}

--- a/packages/eslint-plugin-discord-intl/index.js
+++ b/packages/eslint-plugin-discord-intl/index.js
@@ -12,6 +12,7 @@ module.exports = {
     'no-unicode-variable-names': NativeRules.NoUnicodeVariableNames,
     'no-unnecessary-plural': NativeRules.NoUnnecessaryPlural,
     'no-unsafe-variable-syntax': NativeRules.NoUnsafeVariableSyntax,
+    'no-variable-type-mismatches': NativeRules.NoVariableTypeMismatches,
 
     'use-static-access': require('./rules/use-static-access'),
     'no-opaque-messages-objects': require('./rules/no-opaque-messages-objects'),
@@ -32,6 +33,7 @@ module.exports = {
         '@discord/discord-intl/no-unicode-variable-names': 'error',
         '@discord/discord-intl/no-unnecessary-plural': 'error',
         '@discord/discord-intl/no-unsafe-variable-syntax': 'error',
+        '@discord/discord-intl/no-variable-type-mismatches': 'error',
 
         // JS rules
         '@discord/discord-intl/use-static-access': 'error',

--- a/packages/eslint-plugin-discord-intl/rules/native-rules.js
+++ b/packages/eslint-plugin-discord-intl/rules/native-rules.js
@@ -140,6 +140,17 @@ const NoUnsafeVariableSyntax = createNativeRule({
     },
   },
 });
+const NoVariableTypeMismatches = createNativeRule({
+  diagnosticName: 'NoVariableTypeMismatches',
+  meta: {
+    fixable: 'code',
+    docs: {
+      description:
+        'Disallow variable type changes between source and translation strings',
+      category: 'Correctness',
+    },
+  },
+});
 
 module.exports = {
   NoAvoidableExactPlurals,
@@ -153,5 +164,6 @@ module.exports = {
   NoUnicodeVariableNames,
   NoUnnecessaryPlural,
   NoUnsafeVariableSyntax,
+  NoVariableTypeMismatches,
   createNativeRule,
 };


### PR DESCRIPTION
Add an eslint rule to detect when a variable type has changed between the source and translations. Specifically we see runtime errors when a string used to a function variable but was updated into an any variable. This causes the variable to be called like a function in translations resulting in a runtime exception.

Ex. 
* New source - `{var1}`
* Old translation - `$[var1](var1)`

## Types of transitions

### Case 1: Source was updated from Any to a Specified Type
This is safe because a string like `{count}` can freely become `{count, number}`, because Any is a wider type that encompasses Number.

### Case 2: Source was updated from a Specific Type to Any
This is not safe because a string like `{today, date}` to `{today}` could potentially crash if the type of today was `Date` but is now something else.

### Case 3: Source was updated from a Specific Type to another Specific Type
This depends if the types are interchangeable. Click Handlers and Link typs are interchangeable and safe but Number to Date is not safe.